### PR TITLE
Iterator for requesting unbounded numbers of transactions

### DIFF
--- a/mondo/__init__.py
+++ b/mondo/__init__.py
@@ -159,7 +159,7 @@ class MondoClient():
             return API_ERRORS[r.status_code]
 
     def get_transactions(self, account_id, limit=100, since=None,
-                         before=None, access_token=None):
+                         before=None, access_token=None, merchant=False):
         """
         List transactions
         """
@@ -169,6 +169,9 @@ class MondoClient():
 
         headers = {'Authorization': 'Bearer ' + access_token}
         params = {'limit': limit, "account_id": account_id}
+
+        if merchant:
+            params['expand[]'] = 'merchant'
 
         if since is not None:
             params['since'] = since
@@ -184,7 +187,7 @@ class MondoClient():
             return API_ERRORS[r.status_code]
 
     def iter_transactions(self, account_id, limit=100, since=None,
-                          before=None, access_token=None):
+                          before=None, access_token=None, merchant=False):
         """
         Iterate through all transactions matching the pagination criteria.
 
@@ -196,6 +199,7 @@ class MondoClient():
                 Timestamp limits are inclusive; object IDs are exclusive.
             before: A timestamp all transactions must have been created before.
             access_token: An access token override.
+            merchant: Whether to expand the merchant information.
 
         Yields:
             Individual transaction dicts, as per
@@ -207,7 +211,8 @@ class MondoClient():
         while True:
             trans = self.get_transactions(account_id=account_id, limit=limit,
                                           since=since, before=before,
-                                          access_token=access_token)
+                                          access_token=access_token,
+                                          merchant=merchant)
 
             # TODO: Raise an exception in get_transactions and allow it to
             # bubble up, so that we don't have to check return types. Use that


### PR DESCRIPTION
This new `MondoClient.iter_transactions` method provides a generator between two optional `since`/`before` extents, allowing us to surpass the `limit=100` bound imposed by the API. As the user consumes items from the returned generator we make subsequent requests for more transactions from the API until there are no more results.

Adds a `merchant` parameter to both `{get,iter}_transactions` which indicates whether that field ought to be expanded, as per @BenjaminEHowe's work from elsewhere.
